### PR TITLE
Fix the validation of QUIC transport params

### DIFF
--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1746,12 +1746,14 @@ static int final_quic_transport_params_draft(SSL *s, unsigned int context,
 static int final_quic_transport_params_v1(SSL *s, unsigned int context,
                                           int sent)
 {
-    if (s->ext.peer_quic_transport_params_draft_len == 0
-        && s->ext.peer_quic_transport_params_v1_len == 0) {
-        SSLfatal(s, SSL_AD_MISSING_EXTENSION,
-                 SSL_F_FINAL_QUIC_TRANSPORT_PARAMS,
-                 SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION);
-        return 0;
+    if (s->quic_method != NULL) {
+        if (s->ext.peer_quic_transport_params_draft_len == 0
+            && s->ext.peer_quic_transport_params_v1_len == 0) {
+            SSLfatal(s, SSL_AD_MISSING_EXTENSION,
+                    SSL_F_FINAL_QUIC_TRANSPORT_PARAMS,
+                    SSL_R_MISSING_QUIC_TRANSPORT_PARAMETERS_EXTENSION);
+            return 0;
+        }
     }
 
     return 1;


### PR DESCRIPTION
Hello,

I know the new [quictls / openssl](https://github.com/quictls/openssl/) repository is likely the recommended library to use now, but for people still using your fork, here's a small fix.

Basically, with recent changes, the presence of QUIC transport params was always validated, but it shouldn't if the library is not used for a QUIC connection (e.g. using regular TLS). With this small change, the presence will only be validated if the quic_method were set (which are kind of needed for QUIC to work anyway).